### PR TITLE
go(subroutines) ALL the things!

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,9 @@ This will create a binary for you called `polo`:
 
 If you want try it with the examples:
 
-    $ rm /tmp/db.sqlite;go run -input examples -output /tmp
-    $ cd /tmp
+    $ go run main.go -input examples -output /tmp/test
+    $ cd /tmp/test
     $ python -m SimpleHTTPServer
-
-**Note**: the ``rm /tmp/db.sqlite`` is because of a bug. I can not run the
-database in memory yet, so, you will need to manually delete this file.
 
 And now, you can go to http://localhost:8000 and see your generated blog.
 

--- a/generator/file.go
+++ b/generator/file.go
@@ -179,7 +179,13 @@ func (file ParsedFile) save(db *DB) error {
 		isPageInt = 1
 	}
 
-	if _, err := db.connection.Exec(query, file.Author, file.Title, file.Slug, file.Content, file.Category, file.tags, file.Date, file.status, file.summary, isPageInt); err != nil {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Commit()
+
+	if _, err := tx.Exec(query, file.Author, file.Title, file.Slug, file.Content, file.Category, file.tags, file.Date, file.status, file.summary, isPageInt); err != nil {
 		return err
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -7,33 +7,31 @@ import (
 	"github.com/agonzalezro/polo/generator"
 )
 
-var (
-	inputPath  string
-	outputPath string
-	configFile string
-)
-
-func init() {
-	flag.StringVar(&inputPath, "input", ".", "path to your articles source files.")
-	flag.StringVar(&outputPath, "output", ".", "path where you want to creat the html files.")
-	flag.StringVar(&configFile, "config", "config.json", "the settings file to create your site.")
-}
-
 func main() {
+	var (
+		inputPath = flag.String("input", ".",
+			"path to your articles source files.")
+		outputPath = flag.String("output", ".",
+			"path where you want to creat the html files.")
+		configFile = flag.String("config", "config.json",
+			"the settings file to create your site.")
+	)
 	flag.Parse()
 
-	db, err := generator.GetDB()
+	db, err := generator.NewDB()
 	if err != nil {
 		log.Panic(err)
 	}
-	db.Fill(inputPath)
+	if err := db.Fill(*inputPath); err != nil {
+		log.Panic(err)
+	}
 
-	config, err := generator.ParseConfigFile(configFile)
+	config, err := generator.ParseConfigFile(*configFile)
 	if err != nil {
 		log.Panic(err)
 	}
 
-	site := generator.NewSite(*db, *config, outputPath)
+	site := generator.NewSite(*db, *config, *outputPath)
 	if err := site.Write(); err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
- Moving the writer to subroutines
- Clean the code around the creation of file and paths
- CREATE & INSERT are run inside a transaction now
- all the "own type errors" got removed -> recommended by a proper
  Gopher
- the flags reading was moved to the main() -> recommend by the same
  Gopher (hi @campoy!)
- polo executable was also added to the ignore files.
- I've added caching to the DB queries to avoid problems loosing the
  connection with sqlite3*.
- There are other ways of fixing this (see [1]) when working with sqlite
  and subroutines, but they will require more changes, and caching was
  always an idea in my head.

[1]
https://godoc.org/code.google.com/p/go-sqlite/go1/sqlite3#hdr-Concurrency
